### PR TITLE
Patch Filter::Util::Call for dot in INC

### DIFF
--- a/cpan/Filter-Util-Call/t/call.t
+++ b/cpan/Filter-Util-Call/t/call.t
@@ -1,4 +1,8 @@
 use Config;
+
+use FindBin;
+use lib "$FindBin::Bin/.."; # required to load filter-util.pl
+
 BEGIN {
     if ($ENV{PERL_CORE}) {
         if ($Config{'extensions'} !~ m{\bFilter/Util/Call\b}) {
@@ -7,13 +11,14 @@ BEGIN {
         }
     }
     unshift @INC, 't';
-    require 'filter-util.pl';
 }
 
 use strict;
 use warnings;
 
 use vars qw($Inc $Perl);
+
+require 'filter-util.pl';
 
 print "1..34\n";
 

--- a/cpan/Filter-Util-Call/t/rt_54452-rebless.t
+++ b/cpan/Filter-Util-Call/t/rt_54452-rebless.t
@@ -8,6 +8,10 @@ if ($] < 5.004_55) {
 
 use strict;
 use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/.."; # required to load filter-util.pl
+
 BEGIN { unshift @INC, 't'; }
 
 require "filter-util.pl" ;

--- a/t/TEST
+++ b/t/TEST
@@ -82,7 +82,6 @@ my %temp_no_core =
 # Ideally this # list will eventually be empty
 
 my %temp_needs_dot  = map { $_ => 1 } qw(
-    ../cpan/Filter-Util-Call
     ../cpan/libnet
     ../cpan/Test-Simple
 );


### PR DESCRIPTION
t/call.t was still requiring '.' being in @INC,
add an extra 'use lib' to avoid the issue.